### PR TITLE
Fix recycling when vectors to compare elementwise are of different lengths

### DIFF
--- a/R/FuzzyTokenSet.R
+++ b/R/FuzzyTokenSet.R
@@ -162,14 +162,14 @@ FuzzyTokenSet <- function(inner_comparator = Levenshtein(normalize = TRUE),
 setMethod(elementwise, signature = c(comparator = "FuzzyTokenSet", x = "list", y = "list"), 
           function(comparator, x, y, ...) {
             if (length(x) < length(y)) {
-              x <- rep(x, times = length(y))
+              x <- rep_len(x, length(y))
             } else if (length(y) < length(x)) {
-              y <- rep(y, times = length(x))
+              y <- rep_len(y, length(x))
             }
             
             # Pre-allocate score vector for output
             out <- vector(mode = "numeric", length = length(x))
-            for (i in seq_along(x)) {
+            for (i in seq_along(out)) {
               out[i] <- .impl_inner.OptimalMatch(x[[i]], y[[i]], 
                                                  comparator@inner_comparator, comparator@agg_function, 
                                                  !comparator@distance, comparator@insertion, 

--- a/R/InVocabulary.R
+++ b/R/InVocabulary.R
@@ -107,6 +107,12 @@ InVocabulary <- function(vocab, both_in_distinct = 0.7, both_in_same = 1.0,
 #' `y` are vectors of strings to compare.
 setMethod(elementwise, signature = c(comparator = "InVocabulary", x = "vector", y = "vector"), 
           function(comparator, x, y, ...) {
+            if (length(x) < length(y)) {
+              x <- rep_len(x, length(y))
+            } else if (length(y) < length(x)) {
+              y <- rep_len(y, length(x))
+            }
+            
             vocab <- comparator@vocab
             
             if (comparator@ignore_case) {

--- a/R/Lookup.R
+++ b/R/Lookup.R
@@ -140,6 +140,12 @@ Lookup <- function(lookup_table, values_colnames, score_colname,
 #' are vectors of strings to compare
 setMethod(elementwise, signature = c(comparator = "Lookup", x = "vector", y = "vector"), 
           function(comparator, x, y, ...) {
+            if (length(x) < length(y)) {
+              x <- rep_len(x, length(y))
+            } else if (length(y) < length(x)) {
+              y <- rep_len(y, length(x))
+            }
+            
             if (comparator@ignore_case) {
               x <- tolower(x)
               y <- tolower(y)

--- a/R/MongeElkan.R
+++ b/R/MongeElkan.R
@@ -129,16 +129,14 @@ MongeElkan <- function(inner_comparator = Levenshtein(similarity = TRUE, normali
 #' lists of token vectors to compare.
 setMethod(elementwise, signature = c(comparator = "MongeElkan", x = "list", y = "list"), 
           function(comparator, x, y, ...) {
-            n <- max(length(x), length(y))
-            
             if (length(x) < length(y)) {
-              x <- rep(x, times = length(y))
+              x <- rep_len(x, length(y))
             } else if (length(y) < length(x)) {
-              y <- rep(y, times = length(x))
+              y <- rep_len(y, length(x))
             }
             
-            out <- vector(mode = "numeric", length = n)
-            for (i in seq_len(n)) {
+            out <- vector(mode = "numeric", length = length(x))
+            for (i in seq_along(out)) {
               out[i] <- .impl_inner.MongeElkan(x[[i]], y[[i]], 
                                                comparator@inner_comparator, comparator@inner_opt, 
                                                comparator@agg_function, comparator@symmetric)

--- a/tests/testthat/test-InVocabulary.R
+++ b/tests/testthat/test-InVocabulary.R
@@ -26,3 +26,8 @@ test_that("InVocabulary comparator is correct when ignoring case", {
   expect_equal(comparator("Paul", "paul"), 1)
   expect_equal(comparator("chen", "cheng"), 0.7)
 })
+
+test_that("Recycling is performed correctly for InVocabulary comparator", {
+  expect_equal(comparator("Paul", c("Paul", "cheng", "Saul")), c(1, 0.5, 0.7))
+  expect_equal(comparator(c("Paul", "cheng", "Saul"), "Paul"), c(1, 0.5, 0.7))
+})

--- a/tests/testthat/test-Lookup.R
+++ b/tests/testthat/test-Lookup.R
@@ -39,3 +39,9 @@ test_that("Lookup comparator is correct when ignoring case", {
   expect_equal(comparator("Yellow", "Gold"), 0.1)
   expect_equal(comparator("Amber", "AMBER"), 0)
 })
+
+test_that("Recycling is performed correctly for Lookup comparator", {
+  comparator <- Lookup(lookup_table, c("x", "y"), "s")
+  expect_equal(comparator("Blue", c("Aqua", "Green", "Red")), c(0.2, NA_real_, NA_real_))
+  expect_equal(comparator(c("Aqua", "Green", "Red"), "Blue"), c(0.2, NA_real_, NA_real_))
+})


### PR DESCRIPTION
Fixes issue #4.

This PR implements recycling for the elementwise methods of `InVocabulary` and `Lookup`. It also fixes the recycling implementations for `MongeElkan` and `FuzzyTokenSet`. These previously returned correct results, however they recycled the shorter vector to a longer length than was required.